### PR TITLE
Fix: Transaction Error Human readable

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "watch": "ts-patch i && tsc -w --noEmit",
     "clean": "shx rm -rf ./lib",
     "build:old": "yarn clean && ts-patch i && yarn shx mkdir lib && yarn shx cp -r src lib/src.ts && tsc -p tsconfig.build.json",
-    "es-build": "yarn clean && node esbuild.config.js && tsc -p tsconfig.build.json && shx cp package.json ./lib/package.json",
+    "es-build": "yarn clean && node esbuild.config.js && tsc -p tsconfig.build.json",
     "package": "shx cp -R package.json ./lib && shx cp -R README.md ./lib",
     "publish:pre": "yarn clean && yarn build && yarn package",
     "publish:yalc": "yarn es-build && yarn package && cd lib && yalc publish --no-script --push",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-components",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A set of react components to turbocharge buidling",
   "author": "Austin Griffith <austin@ethereum.org>",
   "repository": "https://github.com/scaffold-eth/eth-components.git",
@@ -22,13 +22,17 @@
     {
       "name": "Shravan Sunder",
       "url": "https://github.com/ShravanSunder"
+    },
+    {
+      "name": "Felipe Novaes Rocha",
+      "url": "https://github.com/kamikazebr"
     }
   ],
   "scripts": {
     "watch": "ts-patch i && tsc -w --noEmit",
     "clean": "shx rm -rf ./lib",
     "build:old": "yarn clean && ts-patch i && yarn shx mkdir lib && yarn shx cp -r src lib/src.ts && tsc -p tsconfig.build.json",
-    "es-build": "yarn clean && node esbuild.config.js && tsc -p tsconfig.build.json",
+    "es-build": "yarn clean && node esbuild.config.js && tsc -p tsconfig.build.json && shx cp package.json ./lib/package.json",
     "package": "shx cp -R package.json ./lib && shx cp -R README.md ./lib",
     "publish:pre": "yarn clean && yarn build && yarn package",
     "publish:yalc": "yarn es-build && yarn package && cd lib && yalc publish --no-script --push",
@@ -133,7 +137,7 @@
     "react": "^17.0.2",
     "react-css-theme-switcher": "^0.3.0",
     "react-dom": "^17.0.2",
-    "shx": "^0.3.3",
+    "shx": "^0.3.4",
     "ts-node": "^10.2.1",
     "ts-patch": "^1.3.4",
     "tsconfig-paths": "^3.11.0",

--- a/src/functions/transactor.ts
+++ b/src/functions/transactor.ts
@@ -1,6 +1,7 @@
 import { TransactionRequest, TransactionResponse } from '@ethersproject/providers';
 import { notification } from 'antd';
 import { ArgsProps } from 'antd/lib/notification';
+import { ArgsProps } from 'antd/lib/message';
 import Notify, { API, InitOptions } from 'bnc-notify';
 import { parseProviderOrSigner } from 'eth-hooks/functions';
 import { TEthersSigner } from 'eth-hooks/models';
@@ -36,8 +37,32 @@ export type TTransactor = (
   callback?: ((_param: any) => void) | undefined
 ) => Promise<Record<string, any> | TransactionResponse | undefined>;
 
+/**
+ *  The {@link NotificationMessage} type is an alias to the correct {@link ArgsProps}.
+ *
+ *  Antd lib have 2 ArgsProps definition (check example below)
+ *  That alias avoid the wrong import when using {@link transactor} function
+ *  with the filter callback {@link TFilterErrorMessage}.
+ *  @example
+ *  ```
+ *  import { ArgsProps } from 'antd/lib/notification';
+ *  import { ArgsProps } from 'antd/lib/message';
+ *  ```
+ */
 export type NotificationMessage = ArgsProps;
 
+/**
+ * A filter callback that act like a middleware to notification messages,
+ * ableing custom the notification errors message and descriptions
+ * messages returning {@link NotificationMessage.message}
+ * and {@link NotificationMessage.description} changed.
+ *
+ * @param settings (IEthComponentsContext)
+ * @param err - {@link TRawTxError} original error was throwed by transaction.
+ * @param notificationMessage - {@link NotificationMessage}
+ * inherits from {@link ArgsProps} contains the default message and description
+ * @returns (NotificationMessage) return {@link NotificationMessage} will be used on notification error.
+ */
 export type TFilterErrorMessage = (err: TRawTxError, notificationMessage: NotificationMessage) => NotificationMessage;
 
 /**
@@ -49,7 +74,7 @@ export type TFilterErrorMessage = (err: TRawTxError, notificationMessage: Notifi
  * @param gasPrice
  * @param etherscan
  * @param throwOnError - throwOnError default value its false, if true it will throw errors.
- * @param filterErrorMessage - receive the @link TxErrorType to custom your errors message and description at notification.
+ * @param filterErrorMessage - receive the {@link TRawTxError} to custom your errors message and description at notification.
  * @returns (TTransactor) a function to transact which calls a callback method parameter on completion
  * @throws {@link TransactorError} class
  */
@@ -171,7 +196,6 @@ export const transactor = (
         const err = e as TRawTxError;
 
         const extractedReason = err.data?.message?.match(/reverted with reason string \'(.*?)\'/);
-        // Accounts for Metamask and default signer on all networks
 
         let notificationMessage: NotificationMessage = {
           message: 'Transaction Error',

--- a/src/functions/transactor.ts
+++ b/src/functions/transactor.ts
@@ -173,7 +173,7 @@ export const transactor = (
         const extractedReason = err.data?.message?.match(/reverted with reason string \'(.*?)\'/);
         // Accounts for Metamask and default signer on all networks
 
-        let notificationMessage: ArgsProps = {
+        let notificationMessage: NotificationMessage = {
           message: 'Transaction Error',
           description: err.message,
         };

--- a/src/functions/transactor.ts
+++ b/src/functions/transactor.ts
@@ -1,7 +1,6 @@
 import { TransactionRequest, TransactionResponse } from '@ethersproject/providers';
 import { notification } from 'antd';
 import { ArgsProps } from 'antd/lib/notification';
-import { ArgsProps } from 'antd/lib/message';
 import Notify, { API, InitOptions } from 'bnc-notify';
 import { parseProviderOrSigner } from 'eth-hooks/functions';
 import { TEthersSigner } from 'eth-hooks/models';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6157,7 +6157,7 @@ __metadata:
     react-css-theme-switcher: ^0.3.0
     react-dom: ^17.0.2
     react-qr-reader: ^2.2.1
-    shx: ^0.3.3
+    shx: ^0.3.4
     ts-node: ^10.2.1
     ts-patch: ^1.3.4
     tsconfig-paths: ^3.11.0
@@ -13719,15 +13719,28 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"shx@npm:^0.3.3":
-  version: 0.3.3
-  resolution: "shx@npm:0.3.3"
+"shelljs@npm:^0.8.5":
+  version: 0.8.5
+  resolution: "shelljs@npm:0.8.5"
+  dependencies:
+    glob: ^7.0.0
+    interpret: ^1.0.0
+    rechoir: ^0.6.2
+  bin:
+    shjs: bin/shjs
+  checksum: 7babc46f732a98f4c054ec1f048b55b9149b98aa2da32f6cf9844c434b43c6251efebd6eec120937bd0999e13811ebd45efe17410edb3ca938f82f9381302748
+  languageName: node
+  linkType: hard
+
+"shx@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "shx@npm:0.3.4"
   dependencies:
     minimist: ^1.2.3
-    shelljs: ^0.8.4
+    shelljs: ^0.8.5
   bin:
     shx: lib/cli.js
-  checksum: 2e408a79c680cef4d719a56563217031ef20d5c2c18fdfe28933e22d833adabd995ad6fa6be087a141832cb17010facfc0288e90a6743c0276b478759fd393e0
+  checksum: 0aa168bfddc11e3fe8943cce2e0d2d8514a560bd58cf2b835b4351ba03f46068f7d88286c2627f4b85604e81952154c43746369fb3f0d60df0e3b511f465e5b8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Related to https://github.com/scaffold-eth/eth-components/issues/36

That fix its point to release v2, if approved we could replicate to v3 too, if make sense.

More info about the fix here - https://github.com/scaffold-eth/eth-components/issues/36#issuecomment-1018172146

In case the another errors not handled or if ether lib change your interface, the developer could easily use the callback `filterErrorMessage` to custom your error message.

![image](https://user-images.githubusercontent.com/691510/150654473-8960b57c-57d9-48eb-9cd9-55e4af7fc741.png)

The callback signature
![image](https://user-images.githubusercontent.com/691510/150654652-07320736-7d53-4ec6-b1db-69a0a127ea2e.png)

An example of use, here you can custom message title and description and get access the raw and original Error.

![image](https://user-images.githubusercontent.com/691510/150654636-2dd70b31-87eb-46bc-a076-1bc92d153b29.png)

That type `NotificationMessage` was created to avoid IDE auto import the wrong ArgsProps type from antd lib

![image](https://user-images.githubusercontent.com/691510/150654485-716d68b4-daba-40ae-8f9a-3859ec8c6e52.png)

### Improvements

- I think its possible rename the types and props to keep consistenty with the rest the project.
- Maybe its possible add the same logic from v3 here too, mentioned here https://github.com/scaffold-eth/eth-components/issues/36#issuecomment-1018087742

### Notes
Sorry for my bad english.