### PR TITLE
fix ether input and layout misalignment issues

### DIFF
--- a/src/ant/Account.tsx
+++ b/src/ant/Account.tsx
@@ -131,26 +131,38 @@ export const Account: FC<IAccountProps> = (props: IAccountProps) => {
   const display = (
     <span>
       {resolvedAddress != null && (
-        <>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+          }}>
           <Address
             punkBlockie
             address={resolvedAddress}
-            fontSize={props.fontSize}
+            fontSize={props.fontSize ?? 18}
             ensProvider={props.ensProvider}
             blockExplorer={props.blockExplorer}
             minimized={false}
           />
-          <Balance address={resolvedAddress} price={props.price} />
-          {resolvedSigner && (
-            <Wallet
-              signer={resolvedSigner}
-              ensProvider={props.ensProvider}
-              localProvider={props.localProvider}
-              price={props.price}
-              color={currentTheme === 'light' ? '#1890ff' : '#2caad9'}
-            />
-          )}
-        </>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+            }}>
+            <Balance address={resolvedAddress} price={props.price} fontSize={18} padding=".25rem 0 .25rem .5rem" />
+            {resolvedSigner && (
+              <Wallet
+                fontSize={24}
+                modalFontSize={20}
+                signer={resolvedSigner}
+                ensProvider={props.ensProvider}
+                localProvider={props.localProvider}
+                price={props.price}
+                color={currentTheme === 'light' ? '#1890ff' : '#2caad9'}
+              />
+            )}
+          </div>
+        </div>
       )}
     </span>
   );

--- a/src/ant/Address.css
+++ b/src/ant/Address.css
@@ -1,0 +1,8 @@
+.Address .ant-typography-copy {
+  transform: translateY(-14%);
+}
+
+.Address {
+  font-family: 'Roboto Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-weight: 300;
+}

--- a/src/ant/Address.tsx
+++ b/src/ant/Address.tsx
@@ -4,6 +4,7 @@ import { useResolveEnsName } from 'eth-hooks/dapps';
 import React, { FC } from 'react';
 import Blockies from 'react-blockies';
 import { useThemeSwitcher } from 'react-css-theme-switcher';
+import './Address.css';
 
 import { PunkBlockie } from '.';
 
@@ -116,7 +117,7 @@ export const Address: FC<IAddressProps> = ({ minimized = false, punkBlockie = fa
 
   if (props.punkBlockie) {
     return (
-      <span style={{ position: 'relative' }}>
+      <span className="Address" style={{ position: 'relative' }}>
         <span style={{ verticalAlign: 'middle' }}>
           <div style={{ position: 'absolute', left: -213, top: -62 }}>
             <PunkBlockie withQr={false} address={address.toLowerCase()} scale={0.4} />
@@ -129,9 +130,15 @@ export const Address: FC<IAddressProps> = ({ minimized = false, punkBlockie = fa
     );
   } else {
     return (
-      <span style={{ display: 'inline-flex', alignItems: 'center' }}>
+      <span className="Address" style={{ display: 'inline-flex', alignItems: 'center' }}>
         <Blockies seed={address.toLowerCase()} size={8} scale={props.fontSize ? props.fontSize / 7 : 4} />
-        <span style={{ verticalAlign: 'middle', paddingLeft: 5, fontSize: props.fontSize ? props.fontSize : 28 }}>
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            paddingLeft: 5,
+            fontSize: props.fontSize ? props.fontSize : 28,
+          }}>
           {text}
         </span>
       </span>

--- a/src/ant/AddressInput.tsx
+++ b/src/ant/AddressInput.tsx
@@ -36,7 +36,7 @@ export const AddressInput: FC<IAddressInputProps> = (props) => {
 
   const scannerButton = (
     <div
-      style={{ marginTop: 4, cursor: 'pointer' }}
+      style={{ marginTop: 4, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '0.25rem' }}
       onClick={(): void => {
         setScan(!scan);
       }}>

--- a/src/ant/Balance.css
+++ b/src/ant/Balance.css
@@ -1,0 +1,3 @@
+.Balance {
+  font-family: 'Roboto Mono', monospace;
+}

--- a/src/ant/Balance.tsx
+++ b/src/ant/Balance.tsx
@@ -2,6 +2,7 @@ import { formatEther } from '@ethersproject/units';
 import { useBalance } from 'eth-hooks';
 import { BigNumber } from 'ethers';
 import React, { FC, useState } from 'react';
+import './Balance.css';
 
 interface IBalanceProps {
   address: string | undefined;
@@ -9,6 +10,8 @@ interface IBalanceProps {
   balance?: BigNumber;
   dollarMultiplier?: number;
   size?: 'short' | 'long';
+  fontSize?: number;
+  padding?: string | number;
 }
 
 /**
@@ -19,6 +22,7 @@ interface IBalanceProps {
   - Provide address={address} and get balance corresponding to given address
   - Provide provider={mainnetProvider} to access balance on mainnet or any other network (ex. localProvider)
   - Provide price={price} of ether and get your balance converted to dollars
+  - Provide fontSize and padding to set thes css properties of the wrapper span
  * @param props
  * @returns (FC)
  */
@@ -45,10 +49,11 @@ export const Balance: FC<IBalanceProps> = (props) => {
 
   return (
     <span
+      className="Balance"
       style={{
         verticalAlign: 'middle',
-        fontSize: props.size ?? 24,
-        padding: 8,
+        fontSize: props.fontSize ?? 24,
+        padding: props.padding ?? 8,
         cursor: 'pointer',
       }}
       onClick={(): void => {

--- a/src/ant/EtherInput.tsx
+++ b/src/ant/EtherInput.tsx
@@ -1,3 +1,4 @@
+import { SwapOutlined } from '@ant-design/icons';
 import { Input } from 'antd';
 import React, { FC, ReactNode, useEffect, useState } from 'react';
 
@@ -34,6 +35,8 @@ interface IEtherInputProps {
   value: string;
   placeholder?: string;
   onChange: (value: string) => void;
+  etherMode?: boolean;
+  switchWidth?: number;
 }
 
 /**
@@ -44,23 +47,33 @@ interface IEtherInputProps {
   - Provide value={value} to specify initial amount of ether
   - Provide placeholder="Enter amount" value for the input
   - Control input change by onChange={value => { setAmount(value);}}
+  - set default currency with etherMode
+  - set css width of currency switch with switchWidth
  * @param props
  * @returns (FC)
  */
 export const EtherInput: FC<IEtherInputProps> = (props) => {
-  const [mode, setMode] = useState(props.price ? 'USD' : 'ETH');
+  const [mode, setMode] = useState(props.etherMode ? 'ETH' : props.price ? 'USD' : 'ETH');
   const [display, setDisplay] = useState<string>();
   const [value, setValue] = useState<string>();
 
   const currentValue: string | undefined = props.value ? props.value : value;
 
   const option = (title: string): ReactNode => {
-    if (props?.price != null) {
+    if (props?.price == null) {
       return <></>;
     }
+
+    const titleWrap = (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.25rem' }}>
+        <SwapOutlined />
+        <span>{title}</span>
+      </div>
+    );
+
     return (
       <div
-        style={{ cursor: 'pointer' }}
+        style={{ cursor: 'pointer', width: props.switchWidth ?? '3.5rem' }}
         onClick={(): void => {
           if (mode === 'USD') {
             setMode('ETH');
@@ -75,7 +88,7 @@ export const EtherInput: FC<IEtherInputProps> = (props) => {
             }
           }
         }}>
-        {title}
+        {titleWrap}
       </div>
     );
   };
@@ -84,10 +97,10 @@ export const EtherInput: FC<IEtherInputProps> = (props) => {
   let addonAfter;
   if (mode === 'USD') {
     prefix = '$';
-    addonAfter = option('USD 🔀');
+    addonAfter = option('USD');
   } else {
     prefix = 'Ξ';
-    addonAfter = option('ETH 🔀');
+    addonAfter = option('ETH');
   }
 
   useEffect((): void => {

--- a/src/ant/Wallet.tsx
+++ b/src/ant/Wallet.tsx
@@ -22,6 +22,8 @@ interface IWalletProps {
   localProvider: StaticJsonRpcProvider | undefined;
   price: number;
   color: string;
+  fontSize?: number;
+  modalFontSize?: number;
 }
 
 /**
@@ -37,6 +39,8 @@ interface IWalletProps {
               (ex. "0xa870" => "user.eth") or you can enter directly ENS name instead of address
   - Provide price={price} of ether and easily convert between USD and ETH
   - Provide color to specify the color of wallet icon
+  - Provide fontSize to specify the size of the wallet Icon
+  - Provide modalFontSize to specify font size for Balance and Address in the wallet modal
  * @param props 
  * @returns (FC)
  */
@@ -51,6 +55,8 @@ export const Wallet: FC<IWalletProps> = (props: IWalletProps) => {
   const [toAddress, setToAddress] = useState<string>('');
   const [publicKey, setPublicKey] = useState<BytesLike>();
 
+  const buttonStyle = { minWidth: '7rem', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' };
+
   const providerSend = props.signer ? (
     <Tooltip title="Wallet">
       <WalletOutlined
@@ -62,7 +68,7 @@ export const Wallet: FC<IWalletProps> = (props: IWalletProps) => {
           padding: 7,
           color: props.color ? props.color : '',
           cursor: 'pointer',
-          fontSize: 28,
+          fontSize: props.fontSize ?? 28,
           verticalAlign: 'middle',
         }}
       />
@@ -93,6 +99,7 @@ export const Wallet: FC<IWalletProps> = (props: IWalletProps) => {
     receiveButton = (
       <Button
         key="hide"
+        style={buttonStyle}
         onClick={(): void => {
           setQr('');
         }}>
@@ -102,6 +109,7 @@ export const Wallet: FC<IWalletProps> = (props: IWalletProps) => {
     privateKeyButton = (
       <Button
         key="hide"
+        style={buttonStyle}
         onClick={(): void => {
           setPublicKey(account);
           setQr('');
@@ -168,6 +176,7 @@ export const Wallet: FC<IWalletProps> = (props: IWalletProps) => {
     receiveButton = (
       <Button
         key="receive"
+        style={buttonStyle}
         onClick={(): void => {
           setQr(account);
           setPublicKey('');
@@ -178,6 +187,7 @@ export const Wallet: FC<IWalletProps> = (props: IWalletProps) => {
     privateKeyButton = (
       <Button
         key="hide"
+        style={buttonStyle}
         onClick={(): void => {
           setPublicKey('');
           setQr('');
@@ -215,6 +225,7 @@ export const Wallet: FC<IWalletProps> = (props: IWalletProps) => {
     receiveButton = (
       <Button
         key="receive"
+        style={buttonStyle}
         onClick={(): void => {
           setQr(account);
           setPublicKey('');
@@ -225,6 +236,7 @@ export const Wallet: FC<IWalletProps> = (props: IWalletProps) => {
     privateKeyButton = (
       <Button
         key="hide"
+        style={buttonStyle}
         onClick={(): void => {
           setPublicKey(account);
           setQr('');
@@ -235,6 +247,7 @@ export const Wallet: FC<IWalletProps> = (props: IWalletProps) => {
   }
 
   const disableSend = amount == null || toAddress == null || (qr != null && qr !== '');
+  const modalFs = props.modalFontSize ?? 20;
 
   return (
     <span>
@@ -242,10 +255,18 @@ export const Wallet: FC<IWalletProps> = (props: IWalletProps) => {
       <Modal
         visible={open}
         title={
-          <div>
-            {account ? <Address address={account} ensProvider={props.ensProvider} /> : <Spin />}
+          <div
+            style={{
+              lineHeight: `${modalFs * 1.5}px`,
+              height: `${modalFs * 1.5}px`,
+              minHeight: 28,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}>
+            {account ? <Address address={account} fontSize={modalFs} ensProvider={props.ensProvider} /> : <Spin />}
             <div style={{ float: 'right', paddingRight: 25 }}>
-              <Balance address={account} dollarMultiplier={props.price} />
+              <Balance address={account} dollarMultiplier={props.price} fontSize={modalFs} />
             </div>
           </div>
         }
@@ -263,6 +284,7 @@ export const Wallet: FC<IWalletProps> = (props: IWalletProps) => {
           privateKeyButton,
           receiveButton,
           <Button
+            style={buttonStyle}
             key="submit"
             type="primary"
             disabled={disableSend}


### PR DESCRIPTION
The fix for the misaligned copy icon of the Address component requires a css file to be imported since the element which needs to be translated is not exposed in our react code.

As a result, when we'll use the eth-components package in scaffold-eth, a css import will be necessary.

If not provided, the icon is still misaligned. I'll PR the pertaining one-liner in scaffold-eth-typescript too.