### PR TITLE
fix: supporting tuples as arrays in FunctionForm

### DIFF
--- a/src/ant/generic-contract/FunctionForm.tsx
+++ b/src/ant/generic-contract/FunctionForm.tsx
@@ -178,7 +178,7 @@ export const FunctionForm: FC<IFunctionForm> = (props) => {
     const args = props.functionFragment.inputs.map((input, inputIndex) => {
       const key = getFunctionInputKey(props.functionFragment, input, inputIndex);
       let value = form[key];
-      if (input.baseType === 'array') {
+      if (input.baseType === 'array' || input.baseType === 'tuple') {
         value = JSON.parse(value);
       } else if (input.type === 'bool') {
         if (value === 'true' || value === '1' || value === '0x1' || value === '0x01' || value === '0x0001') {

--- a/src/ant/generic-contract/GenericContract.tsx
+++ b/src/ant/generic-contract/GenericContract.tsx
@@ -6,7 +6,9 @@ import { BaseContract, ContractFunction } from 'ethers';
 import { FunctionFragment } from 'ethers/lib/utils';
 import React, { FC, PropsWithChildren, ReactElement, useEffect, useState } from 'react';
 
-import { DisplayVariable, FunctionForm, NoContractDisplay } from '~~/ant/generic-contract';
+import { DisplayVariable } from './DisplayVariable';
+import { FunctionForm } from './FunctionForm';
+import { NoContractDisplay } from './NoContractDisplay';
 
 const { Text } = Typography;
 

--- a/src/ant/generic-contract/GenericContract.tsx
+++ b/src/ant/generic-contract/GenericContract.tsx
@@ -6,13 +6,14 @@ import { BaseContract, ContractFunction } from 'ethers';
 import { FunctionFragment } from 'ethers/lib/utils';
 import React, { FC, PropsWithChildren, ReactElement, useEffect, useState } from 'react';
 
-import { DisplayVariable } from './DisplayVariable';
-import { FunctionForm } from './FunctionFrom';
-import { NoContractDisplay } from './NoContractDisplay';
+import { DisplayVariable } from '~~/ant/generic-contract';
+import { FunctionForm } from '~~/ant/generic-contract';
+import { NoContractDisplay } from '~~/ant/generic-contract';
 
 const { Text } = Typography;
 
 import { Account } from '~~/ant';
+
 const isQueryable = (fn: FunctionFragment): boolean =>
   (fn.stateMutability === 'view' || fn.stateMutability === 'pure') && fn.inputs.length === 0;
 

--- a/src/ant/generic-contract/GenericContract.tsx
+++ b/src/ant/generic-contract/GenericContract.tsx
@@ -6,9 +6,7 @@ import { BaseContract, ContractFunction } from 'ethers';
 import { FunctionFragment } from 'ethers/lib/utils';
 import React, { FC, PropsWithChildren, ReactElement, useEffect, useState } from 'react';
 
-import { DisplayVariable } from '~~/ant/generic-contract';
-import { FunctionForm } from '~~/ant/generic-contract';
-import { NoContractDisplay } from '~~/ant/generic-contract';
+import { DisplayVariable, FunctionForm, NoContractDisplay } from '~~/ant/generic-contract';
 
 const { Text } = Typography;
 

--- a/src/ant/generic-contract/index.ts
+++ b/src/ant/generic-contract/index.ts
@@ -1,5 +1,5 @@
 export * from './DisplayVariable';
-export * from './FunctionFrom';
+export * from './FunctionForm';
 export * from './GenericContract';
 export * from './NoContractDisplay';
 export * from './displayUtils';


### PR DESCRIPTION
GenericContract wasn't accepting functions with tuple inputs (It was treated as a normal string). This PR fixes this behavior.